### PR TITLE
chore: Update mender-ci-tools Docker image version to master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     # conrainer with pre-installed mender-artifact and mender-cli tools
     container:
-      image: mendersoftware/mender-ci-tools:mender-master
+      image: mendersoftware/mender-ci-tools:master
     name: Upload a dummy Mender Artifact
     steps:
       # Checkout git repository


### PR DESCRIPTION
As we made mender-ci-workflows release independent, the `:mender-master` tag won't be updated anymore.